### PR TITLE
Fix type mismatch warning

### DIFF
--- a/includes/form-functions.php
+++ b/includes/form-functions.php
@@ -7,7 +7,7 @@
  */
 function wpgh_is_recaptcha_enabled()
 {
-    return in_array( 'on', get_option( 'gh_enable_recaptcha', array() ) );
+    return ( 'on' == get_option( 'gh_enable_recaptcha', '' ) );
 }
 
 /**


### PR DESCRIPTION
get_option returns a string
in_array expects na array

Modified function to compare the result of the get_option to a string, instead of the in_array() check.