### PR TITLE
fix broken substr return in replacements.php

### DIFF
--- a/includes/replacements.php
+++ b/includes/replacements.php
@@ -2637,8 +2637,8 @@ class Replacements implements \JsonSerializable {
 			1 => 0,
 			2 => strlen( $args[0] ),
 		] );
-
-		return substr( $args[0], $args[1], $args[2] );
+		
+		return substr( $args[3], $args[4], $args[5] );
 	}
 
 	/**


### PR DESCRIPTION
Hi Adrian Happy Holidays,

Here is a pull request to fix the currently broken the {substr.{replacement}} code.

Also I think you should rethink the replacement caching because I had to hack my theme's functions.php with the following just to to deal with stale replacement values:

`function disable_replacements_cache_for_form_page() {
	wp_cache_set( 'last_changed', microtime(), 'groundhogg/replacements' );
}
`

`add_action( 'groundhogg/replacements/init', 'disable_replacements_cache_for_form_page');`

Admittedly I was using {substr.{replacement}} on {GET.url_param} I don't think my use case is too unique.

Hopefully this can get merged into the main branch soon so I don't have to use a hacked plugin for too long in production. 

Also as you don't have a public repo for the groundhogg contracts plugin I'm posting a screen shot of the edit required to fix the print button to work.  It look like JQuery was not getting loaded so I added the wp_enqueue_script for it.

![groundhogg-contracts-jquery-signing-bug](https://github.com/user-attachments/assets/41a96d2c-afa5-4373-82b2-302b58cb4106)

I hope you can get this added to your non-public repo.  Thank for the great product.

-Daniel
