### PR TITLE
Handle missing URL parts in fix_to_id

### DIFF
--- a/admin/welcome/welcome-page.php
+++ b/admin/welcome/welcome-page.php
@@ -60,9 +60,13 @@ class Welcome_Page extends Admin_Page {
 	}
 
     public static function fix_to_id( $fix, $prefix = 'fix-' ) {
-	    $fix = wp_parse_url( $fix );
-        return preg_replace( '/[^a-zA-Z0-9-]/', '-', $prefix . $fix['path'] . $fix['query'] . $fix['fragment'] );
-    }
+    	$fix = wp_parse_url( $fix );
+    	return preg_replace(
+        	'/[^a-zA-Z0-9-]/',
+        	'-',
+        	$prefix . ( $fix['path'] ?? '' ) . ( $fix['query'] ?? '' ) . ( $fix['fragment'] ?? '' )
+    	);
+	}
 
 	public function ajax_get_checklist_items() {
 


### PR DESCRIPTION
Prevent PHP notices by using null-coalescing defaults for path, query, and fragment when building the ID from wp_parse_url output. Also reformats the preg_replace call for readability while preserving behavior.